### PR TITLE
Fix FATAL Exception in PostCallActivity

### DIFF
--- a/java/com/android/dialer/postcall/AndroidManifest.xml
+++ b/java/com/android/dialer/postcall/AndroidManifest.xml
@@ -21,6 +21,7 @@
   <activity
       android:name="com.android.dialer.postcall.PostCallActivity"
       android:exported="false"
+      android:theme="@style/Theme.AppCompat.Light"
       android:windowSoftInputMode="adjustResize"/>
   </application>
 </manifest>


### PR DESCRIPTION
Use Theme.AppCompat.Light to fix IllegalStateException for
PostCallActivity extending AppCompatActivity.

Test: am start -n com.android.dialer/.postcall.PostCallActivity

Change-Id: Ica815d43cd8dae73fbc8ec948dd701a1455d1704
Signed-off-by: Taesu Lee <taesu82.lee@samsung.com>