### PR TITLE
Dialer: Fix call log refresh

### DIFF
--- a/java/com/android/dialer/app/calllog/CallLogFragment.java
+++ b/java/com/android/dialer/app/calllog/CallLogFragment.java
@@ -435,8 +435,6 @@ public class CallLogFragment extends Fragment
   @Override
   public void onPause() {
     LogUtil.enterBlock("CallLogFragment.onPause");
-    getActivity().getContentResolver().unregisterContentObserver(callLogObserver);
-    getActivity().getContentResolver().unregisterContentObserver(contactsObserver);
     if (getUserVisibleHint()) {
       onNotVisible();
     }
@@ -470,6 +468,10 @@ public class CallLogFragment extends Fragment
     if (adapter != null) {
       adapter.changeCursor(null);
     }
+    if (callLogObserver != null) {
+      getActivity().getContentResolver().unregisterContentObserver(callLogObserver);
+    }
+    getActivity().getContentResolver().unregisterContentObserver(contactsObserver);
     super.onDestroy();
   }
 


### PR DESCRIPTION
Unregistering observer was in wrong place

* While we at it also move contacts observer

Signed-off-by: Varun Date <date.varun123@gmail.com>