### PR TITLE
 Allow to set maximum brightness for incoming calls

### DIFF
--- a/java/com/android/dialer/app/res/values-pl-rPL/cr_strings.xml
+++ b/java/com/android/dialer/app/res/values-pl-rPL/cr_strings.xml
@@ -30,6 +30,11 @@
     <!-- Full Screen Caller Photo -->
     <string name="fullscreen_caller_photo_title">Zdjęcie na pełen ekran</string>
     <string name="fullscreen_caller_photo_summary">Wyświetl zdjęcie na pełnym ekranie dla połączeń przychodzących oraz wychodzących</string>
+    <!-- Maximum brightness on incoming calls -->
+    <string name="max_brightness_on_incoming_call_mode">Maksymalna jasność ekranu</string>
+    <string name="max_brightness_on_incoming_call_disabled">Wyłączono</string>
+    <string name="max_brightness_on_incoming_call_not_dnd">Poza trybem Nie przeszkadzać</string>
+    <string name="max_brightness_on_incoming_call_always">Zawsze</string>
     <!-- Dialer postcall -->
     <string name="enable_post_call_title">Pokaż połączenie na snackbarze</string>
     <string name="enable_post_call_summary">Włącz powiadomienia o połączeniach w dolnej części ekranu</string>

--- a/java/com/android/dialer/app/res/values/cr_arrays.xml
+++ b/java/com/android/dialer/app/res/values/cr_arrays.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2023 crDroid Android Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string-array name="max_brightness_on_incoming_call_values" translatable="false">
+        <item>"0"</item>
+        <item>"1"</item>
+        <item>"2"</item>
+    </string-array>
+
+    <string-array name="max_brightness_on_incoming_call_entries" translatable="false">
+        <item>@string/max_brightness_on_incoming_call_disabled</item>
+        <item>@string/max_brightness_on_incoming_call_not_dnd</item>
+        <item>@string/max_brightness_on_incoming_call_always</item>
+    </string-array>
+</resources>

--- a/java/com/android/dialer/app/res/values/cr_strings.xml
+++ b/java/com/android/dialer/app/res/values/cr_strings.xml
@@ -36,6 +36,13 @@
     <string name="fullscreen_caller_photo_title">Fullscreen photo</string>
     <string name="fullscreen_caller_photo_summary">Display full-screen photo for incoming and outgoing calls</string>
 
+    <!-- Maximum brightness on incoming calls -->
+    <string name="max_brightness_on_incoming_call_mode">Maximum brightness for incoming calls</string>
+    <string name="max_brightness_on_incoming_call_mode_key" translatable="false">max_brightness_on_incoming_call_mode_key</string>
+    <string name="max_brightness_on_incoming_call_disabled">Disabled</string>
+    <string name="max_brightness_on_incoming_call_not_dnd">Only when not in Do not disturb mode</string>
+    <string name="max_brightness_on_incoming_call_always">Always</string>
+
     <!-- Dialer postcall -->
     <string name="enable_post_call_title">Post call snackbar</string>
     <string name="enable_post_call_summary">Enable post call notifications at the bottom of screen</string>

--- a/java/com/android/dialer/app/res/xml/display_options_settings.xml
+++ b/java/com/android/dialer/app/res/xml/display_options_settings.xml
@@ -43,7 +43,15 @@
       android:key="fullscreen_caller_photo"
       android:title="@string/fullscreen_caller_photo_title"
       android:summary="@string/fullscreen_caller_photo_summary"
-      android:defaultValue="false" />
+      android:defaultValue="false"
       app:iconSpaceReserved="false"/>
-
+      
+  <ListPreference
+      android:key="@string/max_brightness_on_incoming_call_mode_key"
+      android:summary="%s"
+      android:entries="@array/max_brightness_on_incoming_call_entries"
+      android:entryValues="@array/max_brightness_on_incoming_call_values"
+      android:title="@string/max_brightness_on_incoming_call_mode"
+      android:defaultValue="0"
+      app:iconSpaceReserved="false"/>
 </PreferenceScreen>

--- a/java/com/android/incallui/answer/impl/AnswerFragment.java
+++ b/java/com/android/incallui/answer/impl/AnswerFragment.java
@@ -25,6 +25,7 @@ import android.animation.ObjectAnimator;
 import android.annotation.SuppressLint;
 import android.app.KeyguardManager;
 import android.app.KeyguardManager.KeyguardDismissCallback;
+import android.app.NotificationManager;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.content.SharedPreferences;
@@ -40,6 +41,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.AccessibilityDelegate;
 import android.view.ViewGroup;
+import android.view.WindowManager;
 import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityNodeInfo;
 import android.view.accessibility.AccessibilityNodeInfo.AccessibilityAction;
@@ -160,6 +162,9 @@ public class AnswerFragment extends Fragment
   private VideoCallScreen answerVideoCallScreen;
   private final Handler handler = new Handler(Looper.getMainLooper());
   private boolean isFullscreenPhoto = false;
+  private NotificationManager mNotificationManager;
+  private int mDndMode;
+  private boolean shouldSetMaxBrightness;
 
   private enum SecondaryBehavior {
     REJECT_WITH_SMS(
@@ -734,6 +739,20 @@ public class AnswerFragment extends Fragment
     super.onAttach(context);
     FragmentUtils.checkParent(this, InCallScreenDelegateFactory.class);
   }
+  
+  private int getMaxBrightnessMode(Context context) {
+    final String prefName = context.getPackageName() + "_preferences";
+    final SharedPreferences prefs = context.getSharedPreferences(prefName, context.MODE_MULTI_PROCESS);
+    try {
+      String value = prefs.getString(context.getString(R.string.max_brightness_on_incoming_call_mode_key), null);
+      if (value != null) {
+        return Integer.parseInt(value);
+      }
+    } catch (NumberFormatException e) {
+      // ignore and fall through
+    }
+    return 0;
+  }
 
   @Override
   public void onViewCreated(final View view, @Nullable Bundle savedInstanceState) {
@@ -744,6 +763,18 @@ public class AnswerFragment extends Fragment
 
     if (savedInstanceState == null || !savedInstanceState.getBoolean(STATE_HAS_ANIMATED_ENTRY)) {
       ViewUtil.doOnGlobalLayout(view, this::animateEntry);
+    }
+    
+    mNotificationManager = getContext().getSystemService(NotificationManager.class);
+    mDndMode = mNotificationManager.getCurrentInterruptionFilter();
+    int maxBrightnessMode = getMaxBrightnessMode(getContext());
+    shouldSetMaxBrightness = (maxBrightnessMode == 1 && mDndMode == mNotificationManager.INTERRUPTION_FILTER_ALL)
+        || maxBrightnessMode == 2;
+
+    if (shouldSetMaxBrightness) {
+      WindowManager.LayoutParams layoutParams = getActivity().getWindow().getAttributes();
+      layoutParams.screenBrightness = WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_FULL;
+      getActivity().getWindow().setAttributes(layoutParams);
     }
     Trace.endSection();
   }
@@ -925,6 +956,12 @@ public class AnswerFragment extends Fragment
       answerScreenDelegate.onAnswer(answerVideoAsAudio);
       buttonAcceptClicked = true;
     }
+    
+    if (shouldSetMaxBrightness) {
+      WindowManager.LayoutParams layoutParams = getActivity().getWindow().getAttributes();
+      layoutParams.screenBrightness = WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE;
+      getActivity().getWindow().setAttributes(layoutParams);
+    }
   }
 
   private void rejectCall() {
@@ -938,6 +975,12 @@ public class AnswerFragment extends Fragment
       }
       buttonRejectClicked = true;
       answerScreenDelegate.onReject();
+    }
+    
+    if (shouldSetMaxBrightness) {
+      WindowManager.LayoutParams layoutParams = getActivity().getWindow().getAttributes();
+      layoutParams.screenBrightness = WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE;
+      getActivity().getWindow().setAttributes(layoutParams);
     }
   }
 

--- a/java/com/android/incallui/incall/impl/InCallFragment.java
+++ b/java/com/android/incallui/incall/impl/InCallFragment.java
@@ -21,6 +21,7 @@ import android.Manifest;
 import android.Manifest.permission;
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.app.NotificationManager;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.content.SharedPreferences;
@@ -39,6 +40,7 @@ import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.view.Window;
 import android.view.WindowInsets;
+import android.view.WindowManager;
 import android.view.accessibility.AccessibilityEvent;
 import android.widget.ImageView;
 import android.widget.Toast;
@@ -164,6 +166,20 @@ public class InCallFragment extends Fragment
     }
   }
 
+  private int getMaxBrightnessMode(Context context) {
+    final String prefName = context.getPackageName() + "_preferences";
+    final SharedPreferences prefs = context.getSharedPreferences(prefName, context.MODE_MULTI_PROCESS);
+    try {
+      String value = prefs.getString(context.getString(R.string.max_brightness_on_incoming_call_mode_key), null);
+      if (value != null) {
+        return Integer.parseInt(value);
+      }
+    } catch (NumberFormatException e) {
+      // ignore and fall through
+    }
+    return 0;
+  }
+
   @Override
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
@@ -172,6 +188,18 @@ public class InCallFragment extends Fragment
             .newInCallButtonUiDelegate();
     if (savedInstanceState != null) {
       stateRestored = true;
+    }
+    
+    NotificationManager mNotificationManager = getContext().getSystemService(NotificationManager.class);
+    int dndMode = mNotificationManager.getCurrentInterruptionFilter();
+    int maxBrightnessMode = getMaxBrightnessMode(getContext());
+    boolean shouldSetMaxBrightness = (maxBrightnessMode == 1 && dndMode == mNotificationManager.INTERRUPTION_FILTER_ALL)
+        || maxBrightnessMode == 2;
+
+    if (shouldSetMaxBrightness) {
+      WindowManager.LayoutParams layoutParams = getActivity().getWindow().getAttributes();
+      layoutParams.screenBrightness = WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE;
+      getActivity().getWindow().setAttributes(layoutParams);
     }
   }
 


### PR DESCRIPTION
Based on commit a555542 made by @Hikari-no-Tenshi on  Jul 2, 2023. It works fine on Crdroid 9.17 (and earlier versions). It's useful especially during sunny days when "One shot auto-brightness mode" is turned on. The only downside effect is during the night when someone calls it also puts the screen to the maximum brightness what might be a bit too much. If accepted it might be merged into A14, too. Nonetheless, I'm not able to test it.